### PR TITLE
Aewb add

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export SOC=am62a
+rm -rf build
+meson build --prefix=/usr -Dpkg_config_path=pkgconfig
+ninja -C build install
+ldconfig

--- a/ext/tiovx/gsttiovxisp.c
+++ b/ext/tiovx/gsttiovxisp.c
@@ -125,7 +125,6 @@ static const guint postprocess_skip_frames = 1;
 #define ISS_IMX390_GAIN_TBL_SIZE                (71U)
 #define ISS_IMX728_GAIN_TBL_SIZE                (421U)
 
-#define AE_PARAMS_FROM_FILE 1
 aewb_logger_sender_state_t *aewb_logger_sender_state_ptr;
 
 static const uint16_t gIMX390GainsTable[ISS_IMX390_GAIN_TBL_SIZE][2U] = {
@@ -2442,7 +2441,7 @@ static int32_t
 get_imx728_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
 {
   int32_t status = -1;
-#if (AE_PARAMS_FROM_FILE == 0)
+#ifndef AE_PARAMS_FROM_FILE
   uint8_t count = 0;
 
   p_ae_dynPrms->targetBrightnessRange.min = 30;

--- a/ext/tiovx/gsttiovxisp.c
+++ b/ext/tiovx/gsttiovxisp.c
@@ -2006,17 +2006,17 @@ gst_tiovx_isp_fixate_caps (GstTIOVXMiso * self,
 
   if (src_width != width) {
     if (!gst_structure_fixate_field_nearest_int (candidate_output_structure,
-            "width", width)) {
-      GST_ERROR_OBJECT (self, "Could not Fixate Width to %d", width);
-      return NULL;
+          "width", width)) {
+        GST_ERROR_OBJECT (self, "Could not Fixate Width to %d", width);
+        return NULL;
     }
   }
 
   if (src_height != height) {
     if (!gst_structure_fixate_field_nearest_int (candidate_output_structure,
-            "height", height)) {
-      GST_ERROR_OBJECT (self, "Could not Fixate Height to %d", height);
-      return NULL;
+          "height", height)) {
+        GST_ERROR_OBJECT (self, "Could not Fixate Height to %d", height);
+        return NULL;
     }
   }
 
@@ -2520,7 +2520,7 @@ get_ox05b1s_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
 
   /* setting brightness target and range: range is always [target-threshold, target+threshold].
      - numbers in 0~255 range
-   */
+  */
   p_ae_dynPrms->targetBrightnessRange.min = 40; /* lower bound of the target brightness range */
   p_ae_dynPrms->targetBrightnessRange.max = 50; /* upper bound of the target brightness range */
   p_ae_dynPrms->targetBrightness = 45;          /* target brightness */
@@ -2570,7 +2570,7 @@ gst_tiovx_isp_map_2A_values (GstTIOVXISP * self, int exposure_time,
     *analog_gain_mapped = gIMX390GainsTable[i][1];
   } else if (g_strcmp0 (self->sensor_name, "SENSOR_SONY_IMX728") == 0) {
       *analog_gain_mapped = (int)((log2(analog_gain) - 10.0) * 60.0);
-    *exposure_time_mapped = exposure_time;
+      *exposure_time_mapped = exposure_time;
   } else if (g_strcmp0 (self->sensor_name, "SENSOR_SONY_IMX219_RPI") == 0) {
     double multiplier = 0;
     /* Theoretically time per line should be computed as:
@@ -2590,7 +2590,7 @@ gst_tiovx_isp_map_2A_values (GstTIOVXISP * self, int exposure_time,
     *exposure_time_mapped = (60 * 1300 * exposure_time / 1000000);
     // ms to row_time conversion - row_time(us) = 1000000/fps/height
     *analog_gain_mapped = analog_gain;
-  } else if (g_strcmp0 (self->sensor_name, "SENSOR_OX05B1S") == 0) {
+} else if (g_strcmp0 (self->sensor_name, "SENSOR_OX05B1S") == 0) {
     *exposure_time_mapped = (int) ((double)exposure_time * 2128 * 60 / 1000000 + 0.5);
     *analog_gain_mapped = analog_gain / 64;
   } else {

--- a/ext/tiovx/gsttiovxisp.c
+++ b/ext/tiovx/gsttiovxisp.c
@@ -902,10 +902,8 @@ gst_tiovx_isp_ee_mode_get_type (void)
 
   static const GEnumValue targets[] = {
     {TIVX_VPAC_VISS_EE_MODE_OFF, "EE mode off", "EE_MODE_OFF"},
-    {TIVX_VPAC_VISS_EE_MODE_Y12,
-        "Edge Enhancer is enabled on Y12 output (output0)", "EE_MODE_Y12"},
-    {TIVX_VPAC_VISS_EE_MODE_Y8,
-        "Edge Enhancer is enabled on Y8 output (output2)", "EE_MODE_Y8"},
+    {TIVX_VPAC_VISS_EE_MODE_Y12, "Edge Enhancer is enabled on Y12 output (output0)", "EE_MODE_Y12"},
+    {TIVX_VPAC_VISS_EE_MODE_Y8, "Edge Enhancer is enabled on Y8 output (output2)", "EE_MODE_Y8"},
     {0, NULL, NULL},
   };
 
@@ -1185,8 +1183,7 @@ gst_tiovx_isp_class_init (GstTIOVXISPClass * klass)
 
   g_object_class_install_property (gobject_class, PROP_BYPASS_CAC,
       g_param_spec_boolean ("bypass-cac", "Bypass CAC",
-          "Set to bypass chromatic aberation correction (CAC)",
-          default_bypass_cac,
+          "Set to bypass chromatic aberation correction (CAC)", default_bypass_cac,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY |
           G_PARAM_STATIC_STRINGS));
 
@@ -1515,7 +1512,8 @@ gst_tiovx_isp_init_module (GstTIOVXMiso * miso,
   self->viss_obj.input.params.meta_height_after = self->meta_height_after;
   self->viss_obj.input.params.width = GST_VIDEO_INFO_WIDTH (&in_info);
   self->viss_obj.input.params.height = GST_VIDEO_INFO_HEIGHT (&in_info)
-      - self->meta_height_before - self->meta_height_after;
+                                       - self->meta_height_before
+                                       - self->meta_height_after;
 
   format_str = gst_structure_get_string (sink_caps_st, "format");
 
@@ -1972,14 +1970,12 @@ gst_tiovx_isp_fixate_caps (GstTIOVXMiso * self,
 
     if ((-1 != meta_height_before) &&
         (this_meta_height_before != meta_height_before)) {
-      GST_ERROR_OBJECT (self,
-          "Meta height before doesn't match in all sink caps");
+      GST_ERROR_OBJECT (self, "Meta height before doesn't match in all sink caps");
       return NULL;
     }
     if ((-1 != meta_height_after) &&
         (this_meta_height_after != meta_height_after)) {
-      GST_ERROR_OBJECT (self,
-          "Meta height after doesn't match in all sink caps");
+      GST_ERROR_OBJECT (self, "Meta height after doesn't match in all sink caps");
       return NULL;
     }
 
@@ -2455,11 +2451,11 @@ get_imx728_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
   p_ae_dynPrms->threshold = 5;
   p_ae_dynPrms->enableBlc = 0;
 
-  p_ae_dynPrms->exposureTimeStepSize = 1000;    // usec
-  p_ae_dynPrms->exposureTimeRange[count].min = 5000;
-  p_ae_dynPrms->exposureTimeRange[count].max = 5000;
-  p_ae_dynPrms->analogGainRange[count].min = 1 * 1024;
-  p_ae_dynPrms->analogGainRange[count].max = 32228 * 1024;
+  p_ae_dynPrms->exposureTimeStepSize         = 1000;  // usec
+  p_ae_dynPrms->exposureTimeRange[count].min = 5000; 
+  p_ae_dynPrms->exposureTimeRange[count].max = 5000; 
+  p_ae_dynPrms->analogGainRange[count].min = 1*1024;
+  p_ae_dynPrms->analogGainRange[count].max = 32228*1024;
   p_ae_dynPrms->digitalGainRange[count].min = 256;
   p_ae_dynPrms->digitalGainRange[count].max = 256;
   count++;
@@ -2467,8 +2463,10 @@ get_imx728_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
   p_ae_dynPrms->numAeDynParams = count;
 #else
   if (imx728_ae_dynPrms.numAeDynParams == 0) {
+    // load from file only on the first get_imx728_ae_dyn_params() call
     ae_params_get (&imx728_ae_dynPrms);
   }
+
   memcpy (p_ae_dynPrms, &imx728_ae_dynPrms, sizeof (IssAeDynamicParams));
 #endif
 
@@ -2525,9 +2523,9 @@ get_ox05b1s_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
    */
   p_ae_dynPrms->targetBrightnessRange.min = 40; /* lower bound of the target brightness range */
   p_ae_dynPrms->targetBrightnessRange.max = 50; /* upper bound of the target brightness range */
-  p_ae_dynPrms->targetBrightness = 45;  /* target brightness */
-  p_ae_dynPrms->threshold = 5;  /* maximum change above or below the target brightness */
-  p_ae_dynPrms->enableBlc = 0;  /* not used */
+  p_ae_dynPrms->targetBrightness = 45;          /* target brightness */
+  p_ae_dynPrms->threshold = 5;                  /* maximum change above or below the target brightness */
+  p_ae_dynPrms->enableBlc = 0;                  /* not used */
 
   /* setting exposure and gains */
   p_ae_dynPrms->exposureTimeStepSize = 1;       /* step size of automatic adjustment for exposure time */
@@ -2539,12 +2537,12 @@ get_ox05b1s_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
    *   - minimum analog gain is 1x (0x3508=0x01, 0x3509=0x00)
    *   - maximum analog gain is 15.5x (0x3508=0x0F, 0x3509=0x80)
    */
-  p_ae_dynPrms->exposureTimeRange[count].min = 47;      /* 6*16.67/2128*1000 micro sec */
-  p_ae_dynPrms->exposureTimeRange[count].max = 16435;   /* (2128-30)*16.67/2128*1000 micro sec */
-  p_ae_dynPrms->analogGainRange[count].min = 1024;      /* 1x gain - 16*64 */
-  p_ae_dynPrms->analogGainRange[count].max = 15872;     /* 15.5x gain - 16*15.5*64 = 328*64 = 15872 */
-  p_ae_dynPrms->digitalGainRange[count].min = 256;      /* digital gain not used */
-  p_ae_dynPrms->digitalGainRange[count].max = 256;      /* digital gain not used */
+  p_ae_dynPrms->exposureTimeRange[count].min = 47;     /* 6*16.67/2128*1000 micro sec */
+  p_ae_dynPrms->exposureTimeRange[count].max = 16435;  /* (2128-30)*16.67/2128*1000 micro sec */
+  p_ae_dynPrms->analogGainRange[count].min = 1024;     /* 1x gain - 16*64 */
+  p_ae_dynPrms->analogGainRange[count].max = 15872;    /* 15.5x gain - 16*15.5*64 = 328*64 = 15872 */
+  p_ae_dynPrms->digitalGainRange[count].min = 256;     /* digital gain not used */
+  p_ae_dynPrms->digitalGainRange[count].max = 256;     /* digital gain not used */
 
   count++;
 
@@ -2571,7 +2569,7 @@ gst_tiovx_isp_map_2A_values (GstTIOVXISP * self, int exposure_time,
     *exposure_time_mapped = exposure_time;
     *analog_gain_mapped = gIMX390GainsTable[i][1];
   } else if (g_strcmp0 (self->sensor_name, "SENSOR_SONY_IMX728") == 0) {
-    *analog_gain_mapped = (int) ((log2 (analog_gain) - 10.0) * 60.0);
+      *analog_gain_mapped = (int)((log2(analog_gain) - 10.0) * 60.0);
     *exposure_time_mapped = exposure_time;
   } else if (g_strcmp0 (self->sensor_name, "SENSOR_SONY_IMX219_RPI") == 0) {
     double multiplier = 0;
@@ -2593,8 +2591,7 @@ gst_tiovx_isp_map_2A_values (GstTIOVXISP * self, int exposure_time,
     // ms to row_time conversion - row_time(us) = 1000000/fps/height
     *analog_gain_mapped = analog_gain;
   } else if (g_strcmp0 (self->sensor_name, "SENSOR_OX05B1S") == 0) {
-    *exposure_time_mapped =
-        (int) ((double) exposure_time * 2128 * 60 / 1000000 + 0.5);
+    *exposure_time_mapped = (int) ((double)exposure_time * 2128 * 60 / 1000000 + 0.5);
     *analog_gain_mapped = analog_gain / 64;
   } else {
     GST_ERROR_OBJECT (self, "Unknown sensor: %s", self->sensor_name);

--- a/ext/tiovx/gsttiovxisp.c
+++ b/ext/tiovx/gsttiovxisp.c
@@ -2536,7 +2536,7 @@ get_ox05b1s_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
    *        - frame length is height + vertical blanking, which is 2128 for 2592x1944 resolution
    *   - minimum analog gain is 1x (0x3508=0x01, 0x3509=0x00)
    *   - maximum analog gain is 15.5x (0x3508=0x0F, 0x3509=0x80)
-   */
+  */
   p_ae_dynPrms->exposureTimeRange[count].min = 47;     /* 6*16.67/2128*1000 micro sec */
   p_ae_dynPrms->exposureTimeRange[count].max = 16435;  /* (2128-30)*16.67/2128*1000 micro sec */
   p_ae_dynPrms->analogGainRange[count].min = 1024;     /* 1x gain - 16*64 */

--- a/ext/tiovx/gsttiovxisp.c
+++ b/ext/tiovx/gsttiovxisp.c
@@ -2437,8 +2437,7 @@ get_imx390_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
 }
 
 IssAeDynamicParams imx728_ae_dynPrms;
-static int32_t
-get_imx728_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
+static int32_t get_imx728_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
 {
   int32_t status = -1;
 #ifndef AE_PARAMS_FROM_FILE

--- a/ext/tiovx/gsttiovxisp.c
+++ b/ext/tiovx/gsttiovxisp.c
@@ -2436,7 +2436,8 @@ get_imx390_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
   return status;
 }
 
-IssAeDynamicParams imx728_ae_dynPrms;
+//use global var to cache yaml instead of reading yaml from file every frame.
+IssAeDynamicParams imx728_ae_dynPrms; 
 static int32_t get_imx728_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
 {
   int32_t status = -1;

--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,7 @@ c = meson.get_compiler('c')
 
 #C math library
 math_dep = c.find_library('m', required : true)
+aewb_logger_dep = c.find_library ('aewb_logger', required:true)
 
 ## Dependencies
 # Define plugin dependencies
@@ -60,7 +61,8 @@ plugin_deps = [
  gst_allocator,
  gst_video_dep,
  edgeai_apps_utils_dep,
- math_dep
+ math_dep,
+ aewb_logger_dep
  ]
 
 if get_option('dl-plugins').enabled()
@@ -162,7 +164,7 @@ endif
 # Define header directories
 #libgsttiovx_inc_dir = include_directories('libgstc')
 gst_ti_ovx_inc_dir = include_directories('gst-libs/')
-configinc = include_directories('.')
+configinc = include_directories('.', '/usr/include/aewb_logger/')
 
 # Define compiler args and include directories
 c_args = ['-DHAVE_CONFIG_H']

--- a/meson.build
+++ b/meson.build
@@ -195,6 +195,8 @@ if get_option('enable-tidl').enabled() and SOC != 'am62x' and SOC != 'am62p'
   c_args += ['-DENABLE_TIDL']
 endif
 
+c_args += ['-DAE_PARAMS_FROM_FILE']
+
 cpp_args = c_args
 
 # Define installation directories


### PR DESCRIPTION
* added aewb_logger calls to log 2a/3a output in `edgeai-gst-plugins`
    * behavior can be customized by these env vars:
        * `AEWB_LOG_EN` - `0/1` to enable/disable
        * `AEWB_LOG_DEST_IP` - by default 192.168.5.1
        * `AEWB_LOG_DEST_PORT` - by default 8081
* added loading of AE params (min/max exposure, min/max gain, target brightness...) from yaml.
   * `ae_params_get()` will try to find the yaml in these paths (in order of precedence):
   * env var  `AE_PARAMS_PATH`
   * `./ae_params.yaml` (current working dir)
   * `/home/root/app/imx728/dcc_3856x2176/ae_params.yaml`
        *  most users will be loading form this path which is a part of the official release.
* both features above loaded from `/usr/lib/libaewb_logger.so`, which is built/installed as part of the `edgeai-tiovx-apps` build.
this is a new dependency for `edgeai-gst-plugins`.

@YardenLeaf please ignore Renesas style rules, we'll deal with it if/when we ever merge into Renesas
